### PR TITLE
Add TLS manifests only when cert-manager is installed

### DIFF
--- a/pkg/manifests/eventing.go
+++ b/pkg/manifests/eventing.go
@@ -8,29 +8,37 @@ import (
 	"knative.dev/eventmesh-operator/pkg/manifests/transform"
 )
 
-// ForEventing returns the configured manifests for eventing
-func ForEventing(em *v1alpha1.EventMesh) (*Manifests, error) {
+// eventingParser parses eventing manifests
+type eventingParser struct{}
+
+// NewEventingParser creates a new eventing manifest parser
+func NewEventingParser() Parser {
+	return &eventingParser{}
+}
+
+// Parse returns the configured manifests for eventing
+func (p *eventingParser) Parse(em *v1alpha1.EventMesh) (*Manifests, error) {
 	manifests := &Manifests{}
 
-	coreManifests, err := eventingCoreManifests(em)
+	coreManifests, err := p.eventingCoreManifests(em)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eventing core manifests: %w", err)
 	}
 	manifests.Append(coreManifests)
 
-	imcManifests, err := eventingIMCManifests(em)
+	imcManifests, err := p.eventingIMCManifests(em)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eventing IMC manifests: %w", err)
 	}
 	manifests.Append(imcManifests)
 
-	mtBrokerManifests, err := eventingMTBrokerManifests(em)
+	mtBrokerManifests, err := p.eventingMTBrokerManifests(em)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eventing MT channel Broker manifests: %w", err)
 	}
 	manifests.Append(mtBrokerManifests)
 
-	tlsManifests, err := eventingTLSManifests(em)
+	tlsManifests, err := p.eventingTLSManifests(em)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eventing tls manifests: %w", err)
 	}
@@ -41,10 +49,10 @@ func ForEventing(em *v1alpha1.EventMesh) (*Manifests, error) {
 	return manifests, nil
 }
 
-func eventingCoreManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
+func (p *eventingParser) eventingCoreManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	manifests := Manifests{}
 
-	coreManifests, err := loadEventingCoreManifests()
+	coreManifests, err := p.loadEventingCoreManifests()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eventing core manifests: %w", err)
 	}
@@ -61,7 +69,7 @@ func eventingCoreManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	return &manifests, nil
 }
 
-func eventingIMCManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
+func (p *eventingParser) eventingIMCManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	manifests := Manifests{}
 
 	imcManifests, err := loadManifests("eventing-latest", "in-memory-channel.yaml")
@@ -75,7 +83,7 @@ func eventingIMCManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	return &manifests, nil
 }
 
-func eventingMTBrokerManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
+func (p *eventingParser) eventingMTBrokerManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	manifests := Manifests{}
 
 	mtBroker, err := loadManifests("eventing-latest", "mt-channel-broker.yaml")
@@ -89,7 +97,7 @@ func eventingMTBrokerManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	return &manifests, nil
 }
 
-func eventingTLSManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
+func (p *eventingParser) eventingTLSManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	manifests := Manifests{}
 
 	tlsManifests, err := loadManifests("eventing-latest", "eventing-tls-networking.yaml")
@@ -112,7 +120,7 @@ func eventingTLSManifests(em *v1alpha1.EventMesh) (*Manifests, error) {
 	return &manifests, nil
 }
 
-func loadEventingCoreManifests() (mf.Manifest, error) {
+func (p *eventingParser) loadEventingCoreManifests() (mf.Manifest, error) {
 	eventingCoreFiles := []string{
 		"eventing-crds.yaml",
 		"eventing-core.yaml",

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -5,7 +5,13 @@ import (
 	"os"
 
 	mf "github.com/manifestival/manifestival"
+	"knative.dev/eventmesh-operator/pkg/apis/operator/v1alpha1"
 )
+
+// Parser parses manifests for different components
+type Parser interface {
+	Parse(em *v1alpha1.EventMesh) (*Manifests, error)
+}
 
 type Manifests struct {
 	ToApply      mf.Manifest

--- a/pkg/reconciler/eventmesh/controller.go
+++ b/pkg/reconciler/eventmesh/controller.go
@@ -39,7 +39,7 @@ func NewController(
 	mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
 	manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
 
-	eventingParser := manifests.NewEventingParser()
+	eventingParser := manifests.NewEventingParser(crdInformer.Lister())
 	kafkaBrokerParser := manifests.NewKafkaBrokerParser()
 
 	r := &Reconciler{

--- a/pkg/reconciler/eventmesh/controller.go
+++ b/pkg/reconciler/eventmesh/controller.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 	eventmeshinformer "knative.dev/eventmesh-operator/pkg/client/injection/informers/operator/v1alpha1/eventmesh"
 	eventmeshreconciler "knative.dev/eventmesh-operator/pkg/client/injection/reconciler/operator/v1alpha1/eventmesh"
+	"knative.dev/eventmesh-operator/pkg/manifests"
 	"knative.dev/eventmesh-operator/pkg/scaler"
 	crdinformer "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
@@ -38,12 +39,17 @@ func NewController(
 	mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
 	manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
 
+	eventingParser := manifests.NewEventingParser()
+	kafkaBrokerParser := manifests.NewKafkaBrokerParser()
+
 	r := &Reconciler{
-		eventMeshLister:  eventMeshInformer.Lister(),
-		deploymentLister: deploymentInformer.Lister(),
-		crdLister:        crdInformer.Lister(),
-		manifest:         manifest,
-		scaler:           scaler,
+		eventMeshLister:   eventMeshInformer.Lister(),
+		deploymentLister:  deploymentInformer.Lister(),
+		crdLister:         crdInformer.Lister(),
+		manifest:          manifest,
+		scaler:            scaler,
+		eventingParser:    eventingParser,
+		kafkaBrokerParser: kafkaBrokerParser,
 	}
 
 	impl := eventmeshreconciler.NewImpl(ctx, r)

--- a/pkg/reconciler/eventmesh/eventmesh.go
+++ b/pkg/reconciler/eventmesh/eventmesh.go
@@ -19,12 +19,10 @@ package eventmesh
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	"knative.dev/eventing/pkg/apis/feature"
@@ -108,9 +106,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, em *v1alpha1.EventMesh) 
 	// Delete old manifests
 	logger.Debug("Deleting unneeded manifests")
 	if err := r.manifest.Append(manifests.ToDelete).Delete(ctx, mf.IgnoreNotFound(true)); err != nil {
-		if !meta.IsNoMatchError(err) && !strings.Contains(err.Error(), "failed to get API group resources") {
-			return fmt.Errorf("failed to delete manifests: %w", err)
-		}
+		return fmt.Errorf("failed to delete manifests: %w", err)
 	}
 
 	// Apply manifests

--- a/pkg/reconciler/eventmesh/eventmesh.go
+++ b/pkg/reconciler/eventmesh/eventmesh.go
@@ -40,11 +40,13 @@ import (
 )
 
 type Reconciler struct {
-	eventMeshLister  operatorv1alpha1listers.EventMeshLister
-	deploymentLister appsv1listers.DeploymentLister
-	scaler           *scaler.Scaler
-	manifest         mf.Manifest
-	crdLister        apiextensionsv1.CustomResourceDefinitionLister
+	eventMeshLister   operatorv1alpha1listers.EventMeshLister
+	deploymentLister  appsv1listers.DeploymentLister
+	scaler            *scaler.Scaler
+	manifest          mf.Manifest
+	crdLister         apiextensionsv1.CustomResourceDefinitionLister
+	eventingParser    knmf.Parser
+	kafkaBrokerParser knmf.Parser
 }
 
 // Check that our Reconciler implements eventmeshreconciler.Interface
@@ -66,7 +68,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, em *v1alpha1.EventMesh) 
 
 	// Get eventing manifests
 	logger.Debug("Loading eventing core manifests")
-	eventingManifests, err := knmf.ForEventing(em)
+	eventingManifests, err := r.eventingParser.Parse(em)
 	if err != nil {
 		return fmt.Errorf("failed to get eventing manifests: %w", err)
 	}
@@ -74,7 +76,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, em *v1alpha1.EventMesh) 
 
 	// Get EKB manifests
 	logger.Debug("Loading eventing-kafka-broker manifests")
-	ekbManifests, err := knmf.ForEventingKafkaBroker(em)
+	ekbManifests, err := r.kafkaBrokerParser.Parse(em)
 	if err != nil {
 		return fmt.Errorf("failed to get EKB manifests: %w", err)
 	}

--- a/pkg/utils/certmanager.go
+++ b/pkg/utils/certmanager.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+
+	apiextensionsv1listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+func IsCertmanagerInstalled(crdLister apiextensionsv1listers.CustomResourceDefinitionLister) (bool, error) {
+	_, err := crdLister.Get("certificates.cert-manager.io")
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get certificates.cert-manager.io CRD: %w", err)
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
Currently we add the TLS manifests to the "ToDelete" when tls is not enabled. This leads to problems when manifest.Delete() is called, when cert-manager is not installed (as it tries to delete an unknown kind).
This PR addresses it and adds the TLS manifests only when cert-manager is installed